### PR TITLE
Better body font text rendering for Chrome.

### DIFF
--- a/resources/docs.css
+++ b/resources/docs.css
@@ -10,6 +10,7 @@ body {
     margin: 0;
     background-color: #fdfdfd;
     padding: 0;
+    -webkit-font-smoothing: subpixel-antialiased;
 }
 
 /* We use the [Proggy Tiny](http://proggyfonts.com) font (MIT License) when


### PR DESCRIPTION
I added -webkit-font-smoothing: subpixel-antialiased; to body for text to be more readable in Chrome.  -webkit-font-smoothing: none; will be kept in pre/code/samp to allow ProggyTinyTTRegular to render without antialising.
