### PR TITLE
path fix for docs html

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -107,7 +107,7 @@
     file = files[_i];
     link = {
       name: path.basename(file, path.extname(file)),
-      href: _.makeDestination(file)
+      href: _.makeDestination(file).replace(/\\/g,'/')
     };
     parts = file.split('/').splice(1);
     key = parts.length > 1 ? parts[0] : './';


### PR DESCRIPTION
fixes mixed slashes (/home\user/home) in menu href path. happened when linking files in a sub directory on windows
