### PR TITLE
Fixed typo in documentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
 }</code></pre>
         <h2>Output</h2>
         <p>Provides extra visual weight and identifies the primary action in a set of buttons.</p>
-        <textarea class="preview-code" spellcheck="false">&lt;button class="btn primary"&gt;Button&lt;/button&gt;</textarea>
+        <textarea class="preview-code" spellcheck="false">&lt;button class="btn primary"&gt;Primary&lt;/button&gt;</textarea>
         <p>For more in-depth examples, the <a href="examples/styledocco/docs.html">docs</a> file is the documentation of the default StyleDocco CSS file, and an <a href="examples/bootstrap/docs/buttons.html">additional example</a> was generated from a modified file of the Twitter Bootstrap project.
       </div>
     </article>


### PR DESCRIPTION
I think "Button" label in output section should be "Primary".
(I'm sorry, I'm not good at English. :dizzy_face: )
