### PR TITLE
Remove minify processes

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var async = require('async');
-var cleancss = require('clean-css');
 var spawn = require('child_process').spawn;
 var findit = require('findit');
 var fs = require('fs');
@@ -9,7 +8,6 @@ var jade = require('jade');
 var marked = require('marked');
 var mkdirp = require('mkdirp');
 var path = require('path');
-var uglifyjs = require('uglify-js');
 var util = require('util');
 
 var styledocco = require('./styledocco');
@@ -19,8 +17,6 @@ var version = require('./package').version;
 marked.setOptions({ sanitize: false, gfm: true });
 
 // Helper functions
-var mincss = function(css) { return cleancss.process(css); };
-var minjs = uglifyjs;
 var pluck = function(arr, prop) {
   return arr.map(function(item) { return item[prop]; });
 };
@@ -324,8 +320,8 @@ var cli = function(options) {
             sections: file.docs,
             project: { name: options.name, menu: menu },
             resources: {
-              docs: { js: minjs(docsScript), css: mincss(resources.docs.css) },
-              previews: { js: minjs(resources.previews.js), css: mincss(urlsRelative(previewStyles, relativePath)) }
+              docs: { js: docsScript, css: resources.docs.css },
+              previews: { js: resources.previews.js, css: urlsRelative(previewStyles, relativePath) }
             }
           })
         };
@@ -338,7 +334,7 @@ var cli = function(options) {
           sections: styledocco.makeSections([{ docs: resources.readme, code: '' }]),
           project: { name: options.name, menu: menu },
           resources: {
-            docs: { js: minjs(docsScript), css: mincss(resources.docs.css) }
+            docs: { js: docsScript, css: resources.docs.css }
           }
         })
       });

--- a/package.json
+++ b/package.json
@@ -13,13 +13,11 @@
   "preferGlobal": true,
   "dependencies": {
     "async": "0.1.x",
-    "clean-css": "0.4.x",
     "findit": "~1.1.0",
     "jade": "0.23.x",
     "marked": "0.2.x",
     "mkdirp": "0.x.x",
-    "optimist": "0.x.x",
-    "uglify-js": "1.2.x" },
+    "optimist": "0.x.x" },
   "devDependencies": {
     "browserify": "1.13.x",
     "jshint": "0.7.x",


### PR DESCRIPTION
When the file size of CSS and JavaScript is large, minify processes are very slow.

In my project: (142.17s)

```
$ time styledocco path/to/src --include foo.js --include --bar.js
142.17s user 0.19s system 101% cpu 1.524 total
```

applied this patch: (1.35s)

```
$ time styledocco path/to/src --include foo.js --include --bar.js
1.35s user 0.19s system 101% cpu 1.524 total
```
