### PR TITLE
Add minify options

### DIFF
--- a/bin/styledocco
+++ b/bin/styledocco
@@ -37,6 +37,7 @@ var options = optimist
   .describe('out', 'Output directory').alias('o', 'out')['default']('out', 'docs')
   .describe('preprocessor', 'Custom preprocessor command')
   .describe('include', 'Extra CSS/JavaScript to include in previews')
+  .describe('minify', 'Minify CSS/JavaScript')['default']('minify', 'true')
   .describe('verbose', 'Print status messages to stdout')
   .describe('version', 'Display StyleDocco version')
   .argv;

--- a/bin/styledocco
+++ b/bin/styledocco
@@ -37,7 +37,7 @@ var options = optimist
   .describe('out', 'Output directory').alias('o', 'out')['default']('out', 'docs')
   .describe('preprocessor', 'Custom preprocessor command')
   .describe('include', 'Extra CSS/JavaScript to include in previews')
-  .describe('minify', 'Minify CSS/JavaScript')['default']('minify', 'true')
+  .describe('minify', 'Minify CSS/JavaScript')['default']('minify', true)
   .describe('verbose', 'Print status messages to stdout')
   .describe('version', 'Display StyleDocco version')
   .argv;

--- a/cli.js
+++ b/cli.js
@@ -311,6 +311,8 @@ var cli = function(options) {
         }));
       }));
       searchIndex = 'var searchIndex=' + JSON.stringify(searchIndex) + ';';
+      var processJS = function(src) { return options.minify ? minjs(src) : src; };
+      var processCSS = function(src) { return options.minify ? mincss(src) : src; };
       var docsScript = '(function(){' + searchIndex + resources.docs.js + '})();';
       // Render files
       var htmlFiles = files.map(function(file) {
@@ -324,8 +326,8 @@ var cli = function(options) {
             sections: file.docs,
             project: { name: options.name, menu: menu },
             resources: {
-              docs: { js: minjs(docsScript), css: mincss(resources.docs.css) },
-              previews: { js: minjs(resources.previews.js), css: mincss(urlsRelative(previewStyles, relativePath)) }
+              docs: { js: processJS(docsScript), css: processCSS(resources.docs.css) },
+              previews: { js: processJS(resources.previews.js), css: processCSS(urlsRelative(previewStyles, relativePath)) }
             }
           })
         };
@@ -338,7 +340,7 @@ var cli = function(options) {
           sections: styledocco.makeSections([{ docs: resources.readme, code: '' }]),
           project: { name: options.name, menu: menu },
           resources: {
-            docs: { js: minjs(docsScript), css: mincss(resources.docs.css) }
+            docs: { js: processJS(docsScript), css: processCSS(resources.docs.css) }
           }
         })
       });


### PR DESCRIPTION
see also: #105

default:

```
$ time styledocco path/to/src --include foo.js --include --bar.js
142.17s user 0.19s system 101% cpu 1.524 total
```

Use `--no-minify`:

```
$ time styledocco path/to/src --no-minify --include foo.js --include --bar.js
1.33s user 0.19s system 101% cpu 1.501 total
```
