### PR TITLE
Allow whitespace before single-line comments

### DIFF
--- a/styledocco.js
+++ b/styledocco.js
@@ -6,7 +6,7 @@ marked.setOptions({ sanitize: false, gfm: true });
 // Regular expressions to match comments. We only match comments in
 // the beginning of lines. 
 var commentRegexs = {
-  single: /^\/\//, // Single line comments for Sass, Less and Stylus
+  single: /^\s*\/\//, // Single line comments for Sass, Less and Stylus
   multiStart: /^\/\*/,
   multiEnd: /\*\//
 };


### PR DESCRIPTION
useful for LESS/SCSS which allow scoped selectors and namespaces

For example:

```
// # Util mixins
// Various mixins that are sprinkled into other selectors
#utils {

  // ## Page Breaks
  #pb {

    // Break before the current element
    .before(@avoid) {
      /* Some rules ... */
    }
  }  
}
```
