### PR TITLE
Allow whitespace before single-line comments

### DIFF
--- a/src/styledocco.js
+++ b/src/styledocco.js
@@ -7,7 +7,7 @@ marked.setOptions({ sanitize: false, gfm: true });
 // Regular expressions to match comments. We only match comments in
 // the beginning of lines. 
 var commentRegexs = {
-  single: /^\/\//, // Single line comments for Sass, Less and Stylus
+  single: /^\s*\/\//, // Single line comments for Sass, Less and Stylus
   multiStart: /^\/\*/,
   multiEnd: /\*\//
 };

--- a/test/fixtures/comments-indented.css
+++ b/test/fixtures/comments-indented.css
@@ -1,0 +1,4 @@
+  // input[type="text"] { background: white; }
+body {
+    background: white;
+}

--- a/test/fixtures/comments-indented.css.blocks.json
+++ b/test/fixtures/comments-indented.css.blocks.json
@@ -1,0 +1,6 @@
+[
+  {
+    "docs": "input[type=\"text\"] {\n    background: white;\n}",
+    "code": "body {\n    background: white;\n}\n\n"
+  }
+]

--- a/test/fixtures/comments-indented.css.sections.json
+++ b/test/fixtures/comments-indented.css.sections.json
@@ -1,0 +1,8 @@
+[
+  {
+    "title": "",
+    "slug": "",
+    "docs": "<p>input[type=&quot;text&quot;] {\n    background: white;\n}</p>",
+    "code": "body {\n    background: white;\n}"
+  }
+]

--- a/test/parser.js
+++ b/test/parser.js
@@ -22,7 +22,7 @@ if (typeof window === 'undefined') {
   fixturePath = 'fixtures/';
 }
 var fixtures = [ 'asterisk.css', 'code.css', 'comments.css', 'invalid.css',
-                 'normal.css', 'sections.css', 'structured.css' ];
+                 'normal.css', 'sections.css', 'structured.css', 'comments-indented.css' ];
 
 exports["Documentation and code blocks"] = function(test) {
   fixtures.forEach(function(fix) {


### PR DESCRIPTION
useful for LESS/SCSS which allow scoped selectors and namespaces

For example:

```
// # Util mixins
// Various mixins that are sprinkled into other selectors
#utils {

  // ## Page Breaks
  #pb {

    // Break before the current element
    .before(@avoid) {
      /* Some rules ... */
    }
  }  
}
```

Aside: This is being used in conjunction with https://github.com/philschatz/css-coverage.js
