### PR TITLE
Node spawn causes issues with Windows. Replace with cross-spawn.

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -2,7 +2,7 @@
 
 var async = require('async');
 var cleancss = require('clean-css');
-var spawn = require('child_process').spawn;
+var spawn = require('cross-spawn');
 var findit = require('findit');
 var fs = require('fs');
 var jade = require('jade');

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "async": "0.1.x",
     "clean-css": "0.4.x",
+    "cross-spawn": "^0.4.1",
     "findit": "~1.1.0",
     "jade": "0.23.x",
     "marked": "0.2.x",


### PR DESCRIPTION
Should fix https://github.com/jacobrask/styledocco/issues/121.

The errors stem from node's child_process.spawn ignoring PATH_EXT in Windows. See more details here: https://github.com/joyent/node/issues/2318. Replacing the native spawn with cross-spawn fixes these issues and is a more portable way of approaching the problem than attempting to append the appropriate extension to the preprocessor depending on the environment.

NOTE: On older versions of node (I believe < 0.12) this non-breaking warning comes along with cross-spawn:

```
Native thread-sleep not available.
This will result in much slower performance.
You should re-install spawn-sync if possible.
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/jacobrask/styledocco/130)

<!-- Reviewable:end -->
