### PR TITLE
Updated marked dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "clean-css": "0.4.x",
     "findit": "~1.1.0",
     "jade": "0.23.x",
-    "marked": "0.2.x",
+    "marked": "0.3.9",
     "mkdirp": "0.x.x",
     "optimist": "0.x.x",
     "uglify-js": "1.2.x" },


### PR DESCRIPTION
Marked has reported vulnerabilities like this one https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-8854 in older versions.